### PR TITLE
refactor: implement Agent trait for extensible agent system

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -3,66 +3,116 @@ use crate::worktree::WorktreeInfo;
 use anyhow::{Context, Result};
 use std::process::{Command, Stdio};
 
-pub fn start_claude_agent(
-    worktree_info: &WorktreeInfo,
-    system_prompt: Option<&str>,
-    agent_args: &[String],
-) -> Result<()> {
-    println!("Starting Claude agent for branch: {}", worktree_info.branch);
-    println!("Worktree path: {}", worktree_info.path.display());
-
-    let mut cmd = Command::new("claude");
-
-    // Add forwarded agent arguments
-    cmd.args(agent_args);
-
-    if let Some(prompt_name) = system_prompt {
-        let prompt_manager = PromptManager::new()?;
-        let prompt_content = prompt_manager
-            .load_prompt(prompt_name)
-            .with_context(|| format!("Failed to load system prompt: {}", prompt_name))?;
-
-        println!("Using system prompt: {}", prompt_name);
-        cmd.arg("--system-prompt").arg(prompt_content);
-    }
-
-    cmd.current_dir(&worktree_info.path);
-    cmd.stdin(Stdio::inherit());
-    cmd.stdout(Stdio::inherit());
-    cmd.stderr(Stdio::inherit());
-
-    let status = cmd.status().context("Failed to start Claude agent")?;
-
-    if !status.success() {
-        anyhow::bail!("Claude agent exited with error");
-    }
-
-    Ok(())
+pub trait Agent {
+    fn name(&self) -> &str;
+    fn command(&self) -> &str;
+    fn start(
+        &self,
+        worktree_info: &WorktreeInfo,
+        system_prompt: Option<&str>,
+        agent_args: &[String],
+    ) -> Result<()>;
 }
 
-pub fn start_gemini_agent(
-    worktree_info: &WorktreeInfo,
-    agent_args: &[String],
-) -> Result<()> {
-    println!("Starting Gemini agent for branch: {}", worktree_info.branch);
-    println!("Worktree path: {}", worktree_info.path.display());
+pub struct ClaudeAgent;
 
-    let mut cmd = Command::new("gemini");
-
-    // Add forwarded agent arguments
-    cmd.args(agent_args);
-
-    cmd.current_dir(&worktree_info.path);
-    cmd.stdin(Stdio::inherit());
-    cmd.stdout(Stdio::inherit());
-    cmd.stderr(Stdio::inherit());
-
-    let status = cmd.status().context("Failed to start Gemini agent")?;
-
-    if !status.success() {
-        anyhow::bail!("Gemini agent exited with error");
+impl Agent for ClaudeAgent {
+    fn name(&self) -> &str {
+        "claude"
     }
 
-    Ok(())
+    fn command(&self) -> &str {
+        "claude"
+    }
+
+    fn start(
+        &self,
+        worktree_info: &WorktreeInfo,
+        system_prompt: Option<&str>,
+        agent_args: &[String],
+    ) -> Result<()> {
+        println!("Starting Claude agent for branch: {}", worktree_info.branch);
+        println!("Worktree path: {}", worktree_info.path.display());
+
+        let mut cmd = Command::new(self.command());
+
+        // Add forwarded agent arguments
+        cmd.args(agent_args);
+
+        if let Some(prompt_name) = system_prompt {
+            let prompt_manager = PromptManager::new()?;
+            let prompt_content = prompt_manager
+                .load_prompt(prompt_name)
+                .with_context(|| format!("Failed to load system prompt: {}", prompt_name))?;
+
+            println!("Using system prompt: {}", prompt_name);
+            cmd.arg("--system-prompt").arg(prompt_content);
+        }
+
+        cmd.current_dir(&worktree_info.path);
+        cmd.stdin(Stdio::inherit());
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+
+        let status = cmd.status().context("Failed to start Claude agent")?;
+
+        if !status.success() {
+            anyhow::bail!("Claude agent exited with error");
+        }
+
+        Ok(())
+    }
+}
+
+pub struct GeminiAgent;
+
+impl Agent for GeminiAgent {
+    fn name(&self) -> &str {
+        "gemini"
+    }
+
+    fn command(&self) -> &str {
+        "gemini"
+    }
+
+    fn start(
+        &self,
+        worktree_info: &WorktreeInfo,
+        system_prompt: Option<&str>,
+        agent_args: &[String],
+    ) -> Result<()> {
+        println!("Starting Gemini agent for branch: {}", worktree_info.branch);
+        println!("Worktree path: {}", worktree_info.path.display());
+
+        if system_prompt.is_some() {
+            anyhow::bail!("Gemini agent does not support system prompts");
+        }
+
+        let mut cmd = Command::new(self.command());
+
+        // Add forwarded agent arguments
+        cmd.args(agent_args);
+
+        cmd.current_dir(&worktree_info.path);
+        cmd.stdin(Stdio::inherit());
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+
+        let status = cmd.status().context("Failed to start Gemini agent")?;
+
+        if !status.success() {
+            anyhow::bail!("Gemini agent exited with error");
+        }
+
+        Ok(())
+    }
+}
+
+pub fn get_agent(agent_type: &str) -> Result<Box<dyn Agent>> {
+    match agent_type {
+        "claude" => Ok(Box::new(ClaudeAgent)),
+        "gemini" => Ok(Box::new(GeminiAgent)),
+        _ => anyhow::bail!("Unknown agent type: {}", agent_type),
+    }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use clap::Parser;
 use std::env;
 
-use maokai::agent::{start_claude_agent, start_gemini_agent};
-use maokai::cli::{Agents, Commands};
+use maokai::agent::get_agent;
+use maokai::cli::Commands;
 use maokai::config::get_worktree_base_path;
 use maokai::{Cli, WorktreeManager};
 
@@ -34,17 +34,8 @@ async fn main() -> Result<()> {
                 worktree_info.path.display()
             );
 
-            match agent {
-                Agents::Claude => {
-                    start_claude_agent(&worktree_info, system_prompt.as_deref(), &agent_args)?
-                }
-                Agents::Gemini => {
-                    if system_prompt.is_some() {
-                        anyhow::bail!("Gemini agent does not support system prompts");
-                    }
-                    start_gemini_agent(&worktree_info, &agent_args)?
-                }
-            }
+            let agent_impl = get_agent(&agent.to_string())?;
+            agent_impl.start(&worktree_info, system_prompt.as_deref(), &agent_args)?;
         }
         Some(Commands::Ls) => {
             let worktrees = if worktree_manager.is_git_repo() {


### PR DESCRIPTION
## Summary
- Introduces an `Agent` trait to provide a common interface for all agent implementations
- Refactors existing agent code to use trait-based polymorphism instead of separate functions
- Makes the codebase more extensible for adding new agents

## Changes
- Added `Agent` trait with methods: `name()`, `command()`, and `start()`
- Refactored `ClaudeAgent` to implement the `Agent` trait
- Added `GeminiAgent` struct implementing the `Agent` trait
- Updated `get_agent()` factory function to return trait objects
- Replaced function-based approach (`start_claude_agent`, `start_gemini_agent`) with trait-based approach
- Updated `main.rs` to use the new trait-based system

## Benefits
- **Extensibility**: Adding new agents now only requires implementing the `Agent` trait and adding a match arm in `get_agent()`
- **Type safety**: All agents must implement the same interface
- **Code reuse**: Common agent behavior can be shared through trait default implementations
- **Maintainability**: Cleaner separation of concerns with each agent encapsulated in its own struct

## Testing
- [x] Existing Claude agent functionality preserved
- [x] Gemini agent works with the new trait system
- [x] Code compiles without warnings
- [x] All existing CLI commands continue to work

🤖 Generated with [Claude Code](https://claude.ai/code)